### PR TITLE
fix: workaround libbpf-sys Default derive compile error with bindgen 0.71.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ include $(INCLUDE_DIR)/package.mk
 include $(TOPDIR)/feeds/packages/lang/rust/rust-package.mk
 
 CARGO_PKG_VARS+= \
-	BINDGEN_EXTRA_CLANG_ARGS=-I$(shell $(TARGET_CC_NOCACHE) -print-file-name=include)
+	BINDGEN_EXTRA_CLANG_ARGS="--target=$(REAL_GNU_TARGET_NAME) --sysroot=$(TOOLCHAIN_DIR) -I$(shell $(TARGET_CC_NOCACHE) -print-file-name=include)"
 
 # Don't ignore Cargo.lock
 ifeq ($(shell grep -o 'RUST_PKG_LOCKED' $(TOPDIR)/feeds/packages/lang/rust/rust-package.mk 2>/dev/null),)
@@ -62,6 +62,19 @@ endif
 
 # The LLVM_PATH var is required so that einat's build script finds llvm-strip
 TARGET_PATH_PKG:=$(LLVM_PATH):$(TARGET_PATH_PKG)
+
+# Workaround: bindgen 0.71.1 generates Default derive for opaque structs with
+# large array padding ([u8;80]/[u8;56]) which fails to compile (E0277).
+# Fix: cargo fetch downloads libbpf-sys first, then fix-libbpf-sys.sh patches
+# build.rs and invalidates the cargo fingerprint so bindings.rs is regenerated.
+define Build/Compile
+	+$(CARGO_PKG_VARS) \
+		cargo fetch \
+		--manifest-path "$(PKG_BUILD_DIR)/Cargo.toml" \
+		--locked
+	$(CURDIR)/fix-libbpf-sys.sh "$(CARGO_HOME)" "$(PKG_BUILD_DIR)"
+	$(call Build/Compile/Cargo)
+endef
 
 # Platform-specific features
 # $(TOPDIR)/feeds/packages/lang/rust/rust-values.mk

--- a/fix-libbpf-sys.sh
+++ b/fix-libbpf-sys.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# Workaround: bindgen 0.71.1 generates Default derive for opaque structs with
+# large array padding ([u8;80]/[u8;56]) which fails to compile (E0277).
+# This script patches libbpf-sys build.rs after cargo fetch downloads it.
+#
+# Usage: fix-libbpf-sys.sh <CARGO_HOME> <PKG_BUILD_DIR>
+
+CARGO_HOME="$1"
+PKG_BUILD_DIR="$2"
+LIBBPF_SYS_PKG="libbpf-sys-1.5.1+v1.5.1"
+
+src_dir=$(ls -d "${CARGO_HOME}/registry/src/"*/"${LIBBPF_SYS_PKG}" 2>/dev/null | head -1)
+
+if [ -z "${src_dir}" ] || [ ! -f "${src_dir}/build.rs" ]; then
+    echo "fix-libbpf-sys.sh: ${LIBBPF_SYS_PKG} not found in cargo registry, skipping"
+    exit 0
+fi
+
+if grep -q 'no_default("bpf_sock")' "${src_dir}/build.rs"; then
+    echo "fix-libbpf-sys.sh: already patched, skipping"
+    exit 0
+fi
+
+echo "fix-libbpf-sys.sh: patching ${src_dir}/build.rs"
+sed -i 's/\.derive_default(true)/.derive_default(true)\n\t\t.no_default("bpf_sock")\n\t\t.no_default("bpf_flow_keys")/' \
+    "${src_dir}/build.rs" || { echo "fix-libbpf-sys.sh: sed failed"; exit 1; }
+
+echo "fix-libbpf-sys.sh: invalidating cargo fingerprint and cached bindings.rs"
+find "${PKG_BUILD_DIR}/target" -name "bindings.rs" \
+    -path "*/build/libbpf-sys-*/out/bindings.rs" -delete 2>/dev/null
+find "${PKG_BUILD_DIR}/target" -type d -name "libbpf-sys-*" \
+    -path "*/.fingerprint/*" | xargs rm -rf 2>/dev/null
+exit 0


### PR DESCRIPTION
## Problem

`bindgen 0.71.1` incorrectly derives `Default` for opaque structs with large array padding fields in the generated `bindings.rs`:

- `bpf_sock`: `pub __bindgen_padding_0: [u8; 80usize]`
- `bpf_flow_keys`: `pub __bindgen_padding_0: [u8; 56usize]`

This causes `E0277` compile errors:

```
error[E0277]: the trait bound `[u8; 80]: Default` is not satisfied
error[E0277]: the trait bound `[u8; 56]: Default` is not satisfied
```

Reproduces with: `libbpf-sys 1.5.1` + `bindgen 0.71.1` + Rust 1.95.0.

## Root Cause

`libbpf-sys/build.rs` uses `.derive_default(true)` which instructs bindgen to derive `Default` for all structs. bindgen 0.71.1 does not correctly handle opaque structs with large padding arrays, generating code that fails to compile.

## Fix

Add `fix-libbpf-sys.sh` and a `Build/Compile` hook that:

1. Runs `cargo fetch --locked` to ensure `libbpf-sys` source is present in `CARGO_HOME/registry/src/`
2. Patches `build.rs` to add `.no_default("bpf_sock")` and `.no_default("bpf_flow_keys")` to the `bindgen::Builder` chain
3. Invalidates cargo fingerprint and cached `bindings.rs` so the build script reruns and regenerates correct bindings
4. Compiles normally

The patch script is **idempotent**: already-patched environments are detected and skipped.

## Notes

- This is a workaround for a known bindgen 0.71.x issue
- Can be removed once `libbpf-sys` upgrades to a fixed bindgen version
- Tested with a clean build (no pre-existing `build_dir` or cached registry)